### PR TITLE
move _boot.dart to src/; format code

### DIFF
--- a/bin/dhttpd.dart
+++ b/bin/dhttpd.dart
@@ -1,5 +1,3 @@
-import '_boot.dart';
+import 'package:simple_http_server/src/_boot.dart';
 
-main(List<String> args) async {
-  bootServer(args);
-}
+main(List<String> args) => bootServer(args);

--- a/bin/simple_http_server.dart
+++ b/bin/simple_http_server.dart
@@ -1,6 +1,6 @@
-import '_boot.dart';
+import 'package:simple_http_server/src/_boot.dart';
 
-main(List<String> args) async {
+main(List<String> args) {
   print('Warning: using simple_http_server to start the server is deprecated.');
   print('Please use dhttpd instead. Thanks!');
   bootServer(args);

--- a/lib/simple_http_server.dart
+++ b/lib/simple_http_server.dart
@@ -5,31 +5,32 @@ import 'dart:io';
 
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as io;
-import 'package:shelf_static/shelf_static.dart';
 import 'package:shelf_cors/shelf_cors.dart' as shelf_cors;
+import 'package:shelf_static/shelf_static.dart';
 
 const int DEFAULT_PORT = 8080;
 const String DEFAULT_HOST = 'localhost';
 
 class SimpleHttpServer {
   static Future<SimpleHttpServer> start(
-      {String path, int port: DEFAULT_PORT, String allowOrigin, address: DEFAULT_HOST}) async {
+      {String path,
+      int port: DEFAULT_PORT,
+      String allowOrigin,
+      address: DEFAULT_HOST}) async {
     if (path == null) path = Directory.current.path;
 
-    final handler = createStaticHandler(path,
-        defaultDocument: 'index.html');
+    final handler = createStaticHandler(path, defaultDocument: 'index.html');
 
-    final pipeline =
-        const Pipeline().addMiddleware(logRequests());
+    final pipeline = const Pipeline().addMiddleware(logRequests());
 
     if (allowOrigin != null) {
-      final corsHeaders = {
-        'Access-Control-Allow-Origin': allowOrigin,
-      };
-      pipeline.addMiddleware(shelf_cors.createCorsHeadersMiddleware(corsHeaders: corsHeaders));
+      final corsHeaders = {'Access-Control-Allow-Origin': allowOrigin,};
+      pipeline.addMiddleware(
+          shelf_cors.createCorsHeadersMiddleware(corsHeaders: corsHeaders));
     }
 
-    HttpServer server = await io.serve(pipeline.addHandler(handler), address, port);
+    HttpServer server =
+        await io.serve(pipeline.addHandler(handler), address, port);
     return new SimpleHttpServer._(server, path);
   }
 

--- a/lib/src/_boot.dart
+++ b/lib/src/_boot.dart
@@ -1,11 +1,11 @@
 library _boot;
 
 import 'dart:io';
+
 import 'package:args/args.dart';
 import 'package:simple_http_server/simple_http_server.dart';
 
 bootServer(List<String> args) async {
-
   var argParser = new ArgParser()
     ..addOption('port',
         abbr: 'p',
@@ -19,7 +19,8 @@ bootServer(List<String> args) async {
         valueHelp: 'host',
         help: 'The hostname to listen on (defaults to "localhost").')
     ..addOption('allow-origin',
-        valueHelp: 'allow-origin', help: "The value for the 'Access-Control-Allow-Origin' header.")
+        valueHelp: 'allow-origin',
+        help: "The value for the 'Access-Control-Allow-Origin' header.")
     ..addFlag('help', abbr: 'h', negatable: false, help: 'Displays the help.');
 
   var results = argParser.parse(args);
@@ -39,8 +40,11 @@ bootServer(List<String> args) async {
   String path =
       results['path'] != null ? results['path'] : Directory.current.path;
 
-  await SimpleHttpServer.start(path: path, port: port, allowOrigin: results['allow-origin'], address: hostname);
+  await SimpleHttpServer.start(
+      path: path,
+      port: port,
+      allowOrigin: results['allow-origin'],
+      address: hostname);
 
   print('Server started on port $port');
-
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,10 +9,10 @@ environment:
   sdk: ">=1.6.0 <2.0.0"
 
 dependencies:
-  shelf_static: ">=0.2.0 <0.3.0"
-  shelf_cors: ">=0.2.0 <0.3.0"
   args: ">=0.12.0+1 <0.14.0"
+  shelf_cors: ">=0.2.0 <0.3.0"
+  shelf_static: ">=0.2.0 <0.3.0"
 
 executables:
-  simple_http_server:
   dhttpd:
+  simple_http_server:


### PR DESCRIPTION
- move `_boot.dart` to `lib/src/`
- organize imports
- format source

No semantic changes -
