### PR TITLE
Added https support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Pub Package](https://img.shields.io/pub/v/dhttpd.svg)](https://pub.dev/packages/dhttpd)
 [![CI](https://github.com/kevmoo/dhttp/workflows/CI/badge.svg?branch=master)](https://github.com/kevmoo/dhttp/actions?query=workflow%3ACI+branch%3Amaster)
 
-A simple HTTP server that can serve up any directory, built with Dart.
+A simple HTTP(s) server that can serve up any directory, built with Dart.
 Inspired by `python -m SimpleHTTPServer`.
 
 ## Install
@@ -44,6 +44,12 @@ $ dhttpd --help
 -p, --port=<port>    The port to listen on.
                      (defaults to "8080")
     --path=<path>    The path to serve. If not set, the current directory is used.
+    --cert=<cert>    The certificate to use.
+                     If not set, https will not be used.
+                     See the dart documentation about SecurityContext.useCertificateChain for more.
+    --key=<key>      The key of the certificate to use.
+                     If not set, https will not be used.
+                     See the dart documentation about SecurityContext.usePrivateKey for more.
     --host=<host>    The hostname to listen on.
                      (defaults to "localhost")
 -h, --help           Displays the help.

--- a/bin/dhttpd.dart
+++ b/bin/dhttpd.dart
@@ -19,11 +19,23 @@ Future<void> main(List<String> args) async {
     return;
   }
 
+  SecurityContext? securityContext;
+  final cert = options.cert;
+  final key = options.key;
+  if (cert != null && key != null) {
+    print('Using certificate ${options.cert} with key ${options.key} for ssl');
+    securityContext = SecurityContext()
+      ..useCertificateChain(cert)
+      ..usePrivateKey(key);
+  } else {
+    print('Parameter cert/key not set, not using ssl');
+  }
+
   await Dhttpd.start(
-    path: options.path,
-    port: options.port,
-    address: options.host,
-  );
+      path: options.path,
+      port: options.port,
+      address: options.host,
+      securityContext: securityContext);
 
   print('Server started on port ${options.port}');
 }

--- a/lib/dhttpd.dart
+++ b/lib/dhttpd.dart
@@ -29,10 +29,12 @@ class Dhttpd {
   /// connection from the network use either one of the values
   /// [InternetAddress.anyIPv4] or [InternetAddress.anyIPv6] to
   /// bind to all interfaces or the IP address of a specific interface.
+  /// If [securityContext] is non-null, a secure server will be started.
   static Future<Dhttpd> start({
     String? path,
     int port = defaultPort,
     Object address = defaultHost,
+    SecurityContext? securityContext,
   }) async {
     path ??= Directory.current.path;
 
@@ -40,7 +42,8 @@ class Dhttpd {
         .addMiddleware(logRequests())
         .addHandler(createStaticHandler(path, defaultDocument: 'index.html'));
 
-    final server = await io.serve(pipeline, address, port);
+    final server = await io.serve(pipeline, address, port,
+        securityContext: securityContext);
     return Dhttpd._(server, path);
   }
 

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: lines_longer_than_80_chars
+
 import 'package:build_cli_annotations/build_cli_annotations.dart';
 
 part 'options.g.dart';
@@ -23,6 +25,20 @@ class Options {
   final String? path;
 
   @CliOption(
+      valueHelp: 'cert',
+      help: 'The certificate to use.'
+          '\r\nIf not set, https will not be used.'
+          '\r\nSee the dart documentation about SecurityContext.useCertificateChain for more.')
+  final String? cert;
+
+  @CliOption(
+      valueHelp: 'key',
+      help: 'The key of the certificate to use.'
+          '\r\nIf not set, https will not be used.'
+          '\r\nSee the dart documentation about SecurityContext.usePrivateKey for more.')
+  final String? key;
+
+  @CliOption(
       defaultsTo: defaultHost,
       valueHelp: 'host',
       help: 'The hostname to listen on.')
@@ -34,6 +50,8 @@ class Options {
   Options({
     required this.port,
     this.path,
+    this.cert,
+    this.key,
     required this.host,
     required this.help,
   });

--- a/lib/src/options.g.dart
+++ b/lib/src/options.g.dart
@@ -15,6 +15,8 @@ Options _$parseOptionsResult(ArgResults result) => Options(
     port: int.tryParse(result['port'] as String) ??
         _$badNumberFormat(result['port'] as String, 'int', 'port'),
     path: result['path'] as String?,
+    cert: result['cert'] as String?,
+    key: result['key'] as String?,
     host: result['host'] as String,
     help: result['help'] as bool);
 
@@ -27,6 +29,14 @@ ArgParser _$populateOptionsParser(ArgParser parser) => parser
   ..addOption('path',
       help: 'The path to serve. If not set, the current directory is used.',
       valueHelp: 'path')
+  ..addOption('cert',
+      help:
+          'The certificate to use.\r\nIf not set, https will not be used.\r\nSee the dart documentation about SecurityContext.useCertificateChain for more.',
+      valueHelp: 'cert')
+  ..addOption('key',
+      help:
+          'The key of the certificate to use.\r\nIf not set, https will not be used.\r\nSee the dart documentation about SecurityContext.usePrivateKey for more.',
+      valueHelp: 'key')
   ..addOption('host',
       help: 'The hostname to listen on.',
       valueHelp: 'host',


### PR DESCRIPTION
As suggested in #1 dart (and [shelf](https://pub.dev/packages/shelf)) already come with SSL support. The only thing needed to use SSL is to tell shelf to use an initalized [`SecurityContext`](https://api.flutter.dev/flutter/dart-io/SecurityContext-class.html), so I added two simple parameters, which are realy just "command line proxies" for the appropriate `SecurityContext` methods.