### PR TITLE
print out urlBase instead of port

### DIFF
--- a/bin/dhttpd.dart
+++ b/bin/dhttpd.dart
@@ -19,11 +19,11 @@ Future<void> main(List<String> args) async {
     return;
   }
 
-  await Dhttpd.start(
+  final dhttpd = await Dhttpd.start(
     path: options.path,
     port: options.port,
     address: options.host,
   );
 
-  print('Server started on port ${options.port}');
+  print('Server started on port ${dhttpd.urlBase}');
 }


### PR DESCRIPTION
Printing out the URL will allow users to quickly open it from the terminal instead of opening the browser and typing the address manually.