### PR TITLE
Add support for custom response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.1.0
+
+- Add "headers" option to add additional response headers.
+  For example: --headers="header1=value;header2=value;"
+
+- Update minimum Dart SDK to `3.0.0`.
 ## 4.0.2-wip
 
 - Update minimum Dart SDK to `3.0.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,7 @@
 ## 4.1.0
 
 - Add "headers" option to add additional response headers.
-  For example: --headers="header1=value;header2=value;"
-
-- Update minimum Dart SDK to `3.0.0`.
-## 4.0.2-wip
-
+  For example: `--headers="header1=value;header2=value;"`
 - Update minimum Dart SDK to `3.0.0`.
 
 ## 4.0.1

--- a/README.md
+++ b/README.md
@@ -43,12 +43,13 @@ $ dhttpd --path build/web/  # Serves app at http://localhost:8080
 
 ```console
 $ dhttpd --help
--p, --port=<port>    The port to listen on.
-                     (defaults to "8080")
-    --path=<path>    The path to serve. If not set, the current directory is used.
-    --host=<host>    The hostname to listen on.
-                     (defaults to "localhost")
--h, --help           Displays the help.
+-p, --port=<port>          The port to listen on.
+                           (defaults to "8080")
+    --path=<path>          The path to serve. If not set, the current directory is used.
+    --headers=<headers>    HTTP headers to apply to each response. header=value;header2=value
+    --host=<host>          The hostname to listen on.
+                           (defaults to "localhost")
+-h, --help                 Displays the help.
 ```
 
 [path]: https://dart.dev/tools/pub/cmd/pub-global#running-a-script-from-your-path

--- a/bin/dhttpd.dart
+++ b/bin/dhttpd.dart
@@ -33,10 +33,7 @@ Future<void> main(List<String> args) async {
 Map<String, String> _parseKeyValuePairs(String str) {
   final regex = RegExp(r'([\w-]+)=([\w-]+)(;|$)');
   final map = <String, String>{};
-  for (final match in regex.allMatches(str)) {
-    final key = match.group(1)!;
-    final value = match.group(2)!;
-    map[key] = value;
-  }
-  return map;
+  return <String, String>{
+    for (var match in regex.allMatches(str)) match.group(1)!: match.group(2)!,
+  };
 }

--- a/bin/dhttpd.dart
+++ b/bin/dhttpd.dart
@@ -30,10 +30,9 @@ Future<void> main(List<String> args) async {
   print('Server started on port ${options.port}');
 }
 
-Map<String, String> _parseKeyValuePairs(String str) {
-  final regex = RegExp(r'([\w-]+)=([\w-]+)(;|$)');
-  final map = <String, String>{};
-  return <String, String>{
-    for (var match in regex.allMatches(str)) match.group(1)!: match.group(2)!,
-  };
-}
+Map<String, String> _parseKeyValuePairs(String str) => <String, String>{
+      for (var match in _regex.allMatches(str))
+        match.group(1)!: match.group(2)!,
+    };
+
+final _regex = RegExp(r'([\w-]+)=([\w-]+)(;|$)');

--- a/bin/dhttpd.dart
+++ b/bin/dhttpd.dart
@@ -22,8 +22,21 @@ Future<void> main(List<String> args) async {
   await Dhttpd.start(
     path: options.path,
     port: options.port,
+    headers:
+        options.headers != null ? parseKeyValuePairs(options.headers!) : null,
     address: options.host,
   );
 
   print('Server started on port ${options.port}');
+}
+
+Map<String, String> parseKeyValuePairs(String str) {
+  final regex = RegExp(r'([\w-]+)=([\w-]+)(;|$)');
+  final map = <String, String>{};
+  for (final match in regex.allMatches(str)) {
+    final key = match.group(1)!;
+    final value = match.group(2)!;
+    map[key] = value;
+  }
+  return map;
 }

--- a/bin/dhttpd.dart
+++ b/bin/dhttpd.dart
@@ -23,14 +23,14 @@ Future<void> main(List<String> args) async {
     path: options.path,
     port: options.port,
     headers:
-        options.headers != null ? parseKeyValuePairs(options.headers!) : null,
+        options.headers != null ? _parseKeyValuePairs(options.headers!) : null,
     address: options.host,
   );
 
   print('Server started on port ${options.port}');
 }
 
-Map<String, String> parseKeyValuePairs(String str) {
+Map<String, String> _parseKeyValuePairs(String str) {
   final regex = RegExp(r'([\w-]+)=([\w-]+)(;|$)');
   final map = <String, String>{};
   for (final match in regex.allMatches(str)) {

--- a/lib/dhttpd.dart
+++ b/lib/dhttpd.dart
@@ -58,6 +58,5 @@ Middleware _headersMiddleware(Map<String, String>? headers) =>
               responseHeaders[entry.key] = entry.value;
             }
           }
-          final newResponse = response.change(headers: responseHeaders);
-          return newResponse;
+          return response.change(headers: responseHeaders);
         };

--- a/lib/dhttpd.dart
+++ b/lib/dhttpd.dart
@@ -39,7 +39,7 @@ class Dhttpd {
 
     final pipeline = const Pipeline()
         .addMiddleware(logRequests())
-        .addMiddleware(headersMiddleware(headers))
+        .addMiddleware(_headersMiddleware(headers))
         .addHandler(createStaticHandler(path, defaultDocument: 'index.html'));
 
     final server = await io.serve(pipeline, address, port);
@@ -49,7 +49,7 @@ class Dhttpd {
   Future<void> destroy() => _server.close();
 }
 
-Middleware headersMiddleware(Map<String, String>? headers) =>
+Middleware _headersMiddleware(Map<String, String>? headers) =>
     (Handler innerHandler) => (Request request) async {
           final response = await innerHandler(request);
           final responseHeaders = Map<String, String>.from(response.headers);

--- a/lib/dhttpd.dart
+++ b/lib/dhttpd.dart
@@ -33,11 +33,13 @@ class Dhttpd {
     String? path,
     int port = defaultPort,
     Object address = defaultHost,
+    Map<String, String>? headers,
   }) async {
     path ??= Directory.current.path;
 
     final pipeline = const Pipeline()
         .addMiddleware(logRequests())
+        .addMiddleware(headersMiddleware(headers))
         .addHandler(createStaticHandler(path, defaultDocument: 'index.html'));
 
     final server = await io.serve(pipeline, address, port);
@@ -46,3 +48,16 @@ class Dhttpd {
 
   Future<void> destroy() => _server.close();
 }
+
+Middleware headersMiddleware(Map<String, String>? headers) =>
+    (Handler innerHandler) => (Request request) async {
+          final response = await innerHandler(request);
+          final responseHeaders = Map<String, String>.from(response.headers);
+          if (headers != null) {
+            for (var entry in headers.entries) {
+              responseHeaders[entry.key] = entry.value;
+            }
+          }
+          final newResponse = response.change(headers: responseHeaders);
+          return newResponse;
+        };

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -25,7 +25,7 @@ class Options {
   @CliOption(
       valueHelp: 'headers',
       help:
-          'HTTP headers to serve on each request. Format: header1=value;header2=value')
+          'HTTP headers to apply to each response. header=value;header2=value')
   final String? headers;
 
   @CliOption(

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -23,6 +23,12 @@ class Options {
   final String? path;
 
   @CliOption(
+      valueHelp: 'headers',
+      help:
+          'HTTP headers to serve on each request. Format: header1=value;header2=value')
+  final String? headers;
+
+  @CliOption(
       defaultsTo: defaultHost,
       valueHelp: 'host',
       help: 'The hostname to listen on.')
@@ -34,6 +40,7 @@ class Options {
   Options({
     required this.port,
     this.path,
+    this.headers,
     required this.host,
     required this.help,
   });

--- a/lib/src/options.g.dart
+++ b/lib/src/options.g.dart
@@ -23,6 +23,7 @@ Options _$parseOptionsResult(ArgResults result) => Options(
             'port',
           ),
       path: result['path'] as String?,
+      headers: result['headers'] as String?,
       host: result['host'] as String,
       help: result['help'] as bool,
     );
@@ -39,6 +40,12 @@ ArgParser _$populateOptionsParser(ArgParser parser) => parser
     'path',
     help: 'The path to serve. If not set, the current directory is used.',
     valueHelp: 'path',
+  )
+  ..addOption(
+    'headers',
+    help:
+        'HTTP headers to serve on each request. Format: header1=value;header2=value',
+    valueHelp: 'headers',
   )
   ..addOption(
     'host',

--- a/lib/src/options.g.dart
+++ b/lib/src/options.g.dart
@@ -43,8 +43,7 @@ ArgParser _$populateOptionsParser(ArgParser parser) => parser
   )
   ..addOption(
     'headers',
-    help:
-        'HTTP headers to serve on each request. Format: header1=value;header2=value',
+    help: 'HTTP headers to apply to each response. header=value;header2=value',
     valueHelp: 'headers',
   )
   ..addOption(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dhttpd
-version: 4.0.2-wip
+version: 4.1.0
 
 description: A static HTTP file server for easy local hosting of a directory.
 repository: https://github.com/kevmoo/dhttpd

--- a/test/readme_test.dart
+++ b/test/readme_test.dart
@@ -23,12 +23,13 @@ Future<void> _readmeCheck(List<String> args) async {
 
   expect(expected, r'''```console
 $ dhttpd --help
--p, --port=<port>    The port to listen on.
-                     (defaults to "8080")
-    --path=<path>    The path to serve. If not set, the current directory is used.
-    --host=<host>    The hostname to listen on.
-                     (defaults to "localhost")
--h, --help           Displays the help.
+-p, --port=<port>          The port to listen on.
+                           (defaults to "8080")
+    --path=<path>          The path to serve. If not set, the current directory is used.
+    --headers=<headers>    HTTP headers to apply to each response. header=value;header2=value
+    --host=<host>          The hostname to listen on.
+                           (defaults to "localhost")
+-h, --help                 Displays the help.
 ```''');
 
   expect(readme.readAsStringSync(), contains(expected));


### PR DESCRIPTION
This is helpful when you want to return custom response headers. For example, if you want to [enable SharedArrayBuffer](https://stackoverflow.com/questions/68616601/how-to-define-sharedarraybuffer-in-chrome) support for a Flutter app with the skwasm renderer:

```
flutter build --wasm --web-renderer=skwasm
dhttpd --path=build/web_wasm --headers="Cross-Origin-Embedder-Policy=require-corp;Cross-Origin-Opener-Policy=same-origin"
```