### PR TITLE
blast repo changes: auto-publish, github-actions, no-response

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,3 +12,6 @@ jobs:
   publish:
     if: ${{ github.repository_owner == 'kevmoo' }}
     uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+    permissions:
+      id-token: write # Required for authentication using OIDC
+      pull-requests: write # Required for writing the pull request note


### PR DESCRIPTION
This PR contains changes created by the blast repo tool.

- `auto-publish`
- `github-actions`
- `no-response`